### PR TITLE
Fixes filenames typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ They can be found at:
 
 ## Data Ingestion
 1. Clone this repo if you haven't already done so
-2. Open [Data Ingestion CO2 vs Temperature.dbc](./data-ingestion/Data%20Ingestion%20CO2%20vs%20Temperature.py) in [Databricks Community Edition](https://community.cloud.databricks.com/)
+2. Open [Data Ingestion CO2 vs Temperature.py](./data-ingestion/Data%20Ingestion%20CO2%20vs%20Temperature.py) in [Databricks Community Edition](https://community.cloud.databricks.com/)
 ![databricks-import](databricks-import.png)
-3. Follow instructions, move on to following exercises once tests all pass.
+3. Follow instructions, move on to following exercises once all tests pass.
 4. Solutions can be found [here](./data-ingestion/Data%20Ingestion%20CO2%20vs%20Temperature%20Solutions.py).
 
 ## Data Transformation
 1. Clone this repo if you haven't already done so
-2. Open [Data Transformation CO2 vs Temperature.dbc](./data-transformation/Data%20Transformation%20CO2%20vs%20Temperature.py) in [Databricks Community Edition](https://community.cloud.databricks.com/)
+2. Open [Data Transformation CO2 vs Temperature.py](./data-transformation/Data%20Transformation%20CO2%20vs%20Temperature.py) in [Databricks Community Edition](https://community.cloud.databricks.com/)
    ![databricks-import](databricks-import.png)
-3. Follow instructions, move on to following exercises once tests all pass.
+3. Follow instructions, move on to following exercises once all tests pass.
 4. Solutions can be found [here](./data-transformation/Data%20Transformation%20CO2%20vs%20Temperature%20Solutions.py).


### PR DESCRIPTION
The README refers to files with extensions that no longer exists, this PR changes the README so that it matches the filename extensions currently available (e.g. `filename.dbc` -> `filename.py`). 
